### PR TITLE
Updated example repo

### DIFF
--- a/.github/workflows/proton_run.yml
+++ b/.github/workflows/proton_run.yml
@@ -97,7 +97,7 @@ jobs:
 
         if [[ $(jq -r --arg env $environment_name 'has($env)' env_config.json) = "false" ]]; then
           echo "Missing $env from env_config.json, existing"
-          exit 0
+          exit 1
         fi
 
         echo "::set-output name=working-directory::$working_directory"

--- a/.github/workflows/proton_run.yml
+++ b/.github/workflows/proton_run.yml
@@ -7,10 +7,8 @@ on:
   push:
     branches:
       - main
-    paths-ignore:
-      - '.github/**'
-      - 'env_config.json'
-      - 'sample-templates/**'
+    paths:
+      - '**/.proton/deployment-metadata.json'
 
 jobs:
   get-deployment-data:
@@ -18,12 +16,13 @@ jobs:
     runs-on: ubuntu-latest
     
     outputs:
-      role-arn: ${{ steps.get-data.outputs.role-arn }}
+      role_arn: ${{ steps.get-data.outputs.role_arn }}
       environment: ${{ steps.get-data.outputs.environment }}
       resource-arn: ${{ steps.get-data.outputs.resource-arn }}
       working-directory: ${{ steps.get-data.outputs.working-directory }}
       deployment-id: ${{ steps.get-data.outputs.deployment-id }}
-      region: ${{ steps.get-data.outputs.region }}
+      aws_region: ${{ steps.get-data.outputs.aws_region }}
+      state_bucket: ${{ steps.get-data.outputs.state_bucket }}
     
     permissions:
       id-token: write
@@ -47,7 +46,7 @@ jobs:
             echo "found file"
             if [[ "$found" == true ]]; then
               echo "More than one resource found to have a new deployment, I'm not sure which one to update, exiting."
-              exit 0
+              exit 1
             fi
             echo "setting found to true"
             found=true
@@ -55,6 +54,10 @@ jobs:
             echo "::set-output name=deployment-metadata-path::$changed_file"
           fi
         done
+        if [[ "$found" == false ]]; then
+          echo "No change made to deployment-metadata.json, exiting"
+          exit 1
+        fi
     
     - name: Get data
       id: get-data
@@ -91,22 +94,32 @@ jobs:
 
           working_directory=pipeline/$service_name
         fi
+
+        if [[ $(jq -r --arg env $environment_name 'has($env)' env_config.json) = "false" ]]; then
+          echo "Missing $env from env_config.json, existing"
+          exit 0
+        fi
+
         echo "::set-output name=working-directory::$working_directory"
         echo "::set-output name=environment::$environment_name"
         
         role_arn=$(jq -r --arg env $environment_name '.[$env]["role"]' env_config.json)
-        echo "::set-output name=role-arn::$role_arn"
+        echo "::set-output name=role_arn::$role_arn"
 
-        region=$(jq -r --arg env $environment_name '.[$env]["region"]' env_config.json)
-        echo "::set-output name=region::$region"
+        aws_region=$(jq -r --arg env $environment_name '.[$env]["region"]' env_config.json)
+        echo "::set-output name=aws_region::$aws_region"
+
+        state_bucket=$(jq -r --arg env $environment_name '.[$env]["state_bucket"]' env_config.json)
+        echo "::set-output name=state_bucket::$state_bucket"
     
   call-terraform-workflow:
     needs: get-deployment-data
     uses: aws-samples/aws-proton-terraform-github-actions-sample/.github/workflows/terraform.yml@main
     with:
-      role_arn: ${{ needs.get-deployment-data.outputs.role-arn }}
+      role_arn: ${{ needs.get-deployment-data.outputs.role_arn }}
       environment: ${{ needs.get-deployment-data.outputs.environment }}
       resource_arn: ${{ needs.get-deployment-data.outputs.resource-arn }}
       working_directory: ${{ needs.get-deployment-data.outputs.working-directory }}
       deployment_id: ${{ needs.get-deployment-data.outputs.deployment-id }}
-      aws_region: ${{ needs.get-deployment-data.outputs.region }}
+      aws_region: ${{ needs.get-deployment-data.outputs.aws_region }}
+      state_bucket: ${{ needs.get-deployment-data.outputs.state_bucket }}

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -58,7 +58,6 @@ on:
       aws_region:
         description: 'AWS region'
         required: false
-        default: 'us-west-2'
         type: string
       working_directory:
         description: 'Directory containining the terraform code to run'
@@ -70,6 +69,10 @@ on:
         type: string
       deployment_id:
         description: 'Deployment id for current run provided in proton deployment metadata file'
+        required: true
+        type: string
+      state_bucket:
+        description: 'Bucket to store generated state files'
         required: true
         type: string
 
@@ -100,7 +103,7 @@ jobs:
         aws-region: ${{ inputs.aws_region }}
         role-to-assume: ${{ inputs.role_arn }}
         role-session-name: TF-Github-Actions
-      continue-on-error: true
+      continue-on-error: false
 
     # Install the latest version of Terraform CLI and configure the Terraform CLI configuration file with a Terraform Cloud user API token
     - name: Setup Terraform
@@ -115,7 +118,7 @@ jobs:
     #######################################################
     # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
     - name: Terraform Init
-      run: terraform init -backend-config="bucket=my-proton-terraform-state-bucket" -backend-config="key=${{ inputs.working_directory }}terraform.tfstate" -backend-config="region=us-west-2"
+      run: terraform init -backend-config="bucket=${{ inputs.state_bucket }}" -backend-config="key=${{ inputs.working_directory }}terraform.tfstate" -backend-config="region=${{ inputs.aws_region }}"
       continue-on-error: true
 
     # Checks that all Terraform configuration files adhere to a canonical format
@@ -125,7 +128,7 @@ jobs:
 
     # Generates an execution plan for Terraform
     - name: Terraform Plan
-      run: terraform plan
+      run: terraform plan -var="aws_region=${{ inputs.aws_region }}"
       continue-on-error: true
 
     # On push to main, build or change infrastructure according to Terraform configuration files
@@ -133,7 +136,7 @@ jobs:
     - name: Terraform Apply
       id: tf_apply
       if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-      run: terraform apply -auto-approve
+      run: terraform apply -auto-approve -var="aws_region=${{ inputs.aws_region }}"
       continue-on-error: true
 
     # This is a temporary measure until we have launched

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -58,6 +58,7 @@ on:
       aws_region:
         description: 'AWS region'
         required: false
+        default: 'us-west-2'
         type: string
       working_directory:
         description: 'Directory containining the terraform code to run'

--- a/GitHubConfiguration.yaml
+++ b/GitHubConfiguration.yaml
@@ -1,7 +1,6 @@
 Parameters:
   FullRepoName:
     Type: String
-    Default: rafavallina/tf-os-sample
 
 Resources:
   Role:
@@ -32,18 +31,19 @@ Resources:
     Type: AWS::IAM::OIDCProvider
     Properties:
       Url: https://token.actions.githubusercontent.com
-      ThumbprintList: [a031c46782e6e6c662c2c87c76da9aa62ccabd8e]
+      ThumbprintList: [6938fd4d98bab03faadb97b34396831e3780aea1]
       ClientIdList:
         - sigstore
         - sts.amazon.com
 
   StateFileBucket:
     # This bucket will be used to store your Terraform Open Source state files
-    # Enter the bucket name in your .github/workflows/terraform.yml file
     Type: AWS::S3::Bucket
     Properties:
-      BucketName: !Ref "AWS::StackName"
-
+      BucketName: !Join
+       - ''
+       - - 'aws-proton-terraform-bucket-'
+         - !Ref AWS::AccountId
 Outputs:
   Role:
     Description: "The role that will be used to provision infrastructure. Enter it in your env_config.json file"

--- a/README.md
+++ b/README.md
@@ -6,18 +6,62 @@ Welcome! This repository should help you test how Proton works with Terraform Op
 2. A GitHub Actions task to run Terraform Open Source based on commits to this repo
 3. An AWS Proton sample template that uses Terraform files to work
 
-To configure this sample, follow this instructiuons:
-1. Clone this repository
-2. In the GitHubConfiguration.yaml file, update the input parameters to your username and repository name
-3. Run GitHubConfiguration.yaml through CloudFormation (https://aws.amazon.com/cloudformation/). This will create a role that GitHub Actions will use to provision resources into your account, as well as an S3 bucket to store Terraform Open Source state files. Make sure you use all lowercase names in the stack name, as we will use it to create an S3 bucket to save your state files
-4. Open the file env_config.json and update the role ARN with the output from (3), the environment name with the name of the environment you are going to create and the region with your preferred deployment region. This will tell Terraform the role and region to use for deployments. You can use different roles for each environment by adding them to this file
-5. Open the file .github/workflows/terraform.yml and update the S3 bucket with the output from (3). This will tell Terraform where to store the state file
-6. Take the sample template and create a Proton environment template by following the instructions here https://docs.aws.amazon.com/proton/latest/adminguide/template-create.html
-7. Register your repository with Proton by following the instructions here: https://docs.aws.amazon.com/proton/latest/adminguide/ag-repositories.html
-8. Deploy your environment in Proton by following the instructions here: https://docs.aws.amazon.com/proton/latest/adminguide/ag-environments.html
-9. Sortly after you trigger the deployment, come back to your repository to see the Pull Request. Once you merge it, you can go back to Proton and see the updated status of your newly created environment
+## How to:
 
-Fell free to reach out with questions or open a ticket with suggestions in our public roadmap at https://github.com/aws/aws-proton-public-roadmap
+You will need the following:
+- `$ENVIRONMENT_NAME`: the name of the environment you plan to create, this can be any name you would like
+- `$REGION`: the region into which you will be deploying this service
+- `$TEMPLATE_BUCKET`: An S3 bucket in which you can store your Proton templates
+- `$GITHUB_USER`: A GitHub account with which you can fork this repository
+
+When you see these strings in the instructions below, you should replace them with the value you have chosen.
+
+1. Fork this repository into your GitHub account
+2. We will be using Github Actions to deploy our Terraform template, and notify Proton of the deployment status. You can see the steps of our workflow in [proton_run.yml](https://github.com/aws-samples/aws-proton-terraform-github-actions-sample/blob/main/.github/workflows/proton_run.yml) and [terraform.yml](https://github.com/aws-samples/aws-proton-terraform-github-actions-sample/blob/main/.github/workflows/terraform.yml). Forked repositories do not have Actions enabled by default, see [this page](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository) for information on how to enable them.
+3. Ensure you have a CodeStar Connection set up for the account into which you
+   forked the repo in the previous step. For information on how to set that up see [this documentation](https://docs.aws.amazon.com/dtconsole/latest/userguide/connections-create.html).
+4. Run GitHubConfiguration.yaml through CloudFormation (https://aws.amazon.com/cloudformation/). This will create a role that GitHub Actions will use to provision resources into your account, as well as an S3 bucket to store Terraform Open Source state files. Make sure you use all lowercase names in the stack name, as we will use it to create an S3 bucket to save your state files.
+```
+aws cloudformation create-stack --stack-name aws-proton-terraform-role-stack \
+   --template-body file:///$PWD/GitHubConfiguration.yaml \
+   --parameters ParameterKey=FullRepoName,ParameterValue=GITHUB_USER/aws-proton-terraform-github-actions-sample \
+   --capabilities CAPABILITY_NAMED_IAM
+```
+5. Open the file `env_config.json`. Add a new object to the configuration dictionary where the key is `ENVIRONMENT_NAME`, `role` is the `Role` output from the stack created in (3), and the region with `REGION`. This will tell Terraform the role and region to use for deployments. You can use different roles for each environment by adding them to this file
+6. In the same file update `state_bucket` with the `BucketName` output from (3). This will tell Terraform where to store the state file.
+7. Commit your changes and push them to your forked repository.
+8. Take the sample template and create a Proton environment template by following the instructions. Make sure to replace `TEMPLATE_BUCKET` with the name of the bucket in which you would like to store your Proton templates. For more information see the documentation [here](https://docs.aws.amazon.com/proton/latest/adminguide/template-create.html)
+```
+tar -zcvf sample-vpc-environment-template.tar.gz sample-templates/sample-vpc-environment-template/
+aws s3 cp sample-vpc-environment-template.tar.gz s3://TEMPLATE_BUCKET/sample-vpc-environment-template.tar.gz
+rm sample-vpc-environment-template.tar.gz
+
+aws proton create-environment-template --name "sample-vpc-environment-template"
+aws proton create-environment-template-version \
+        --template-name sample-vpc-environment-template \
+        --description "Sample template for setting up a Pull Request environment" \
+        --source s3="{bucket=TEMPLATE_BUCKET, key=sample-vpc-environment-template.tar.gz}" \
+        --region REGION
+aws proton update-environment-template-version \
+        --template-name "sample-vpc-environment-template" \
+        --major-version "1" \
+        --minor-version "0" \
+        --status "PUBLISHED" \
+        --region REGION
+```
+9. Register your repository with Proton by following the instructions [here](https://docs.aws.amazon.com/proton/latest/adminguide/ag-create-repo.html)
+10. Deploy your environment in Proton by following the instructions [here](https://docs.aws.amazon.com/proton/latest/adminguide/ag-create-env.html#ag-create-env-pull-request). Change `GITHUB_USER` to be name of the GitHub account with the forked repository.
+```
+ aws proton create-environment \
+        --name "ENVIRONMENT_NAME" \
+        --template-name "sample-vpc-environment-template" \
+        --template-major-version "1" \
+        --provisioning-repository="branch=main,name=GITHUB_USER/aws-proton-terraform-github-actions-sample,provider=GITHUB" \
+        --spec file:///$PWD/specs/env-spec.yml
+```
+11. Shortly after you trigger the deployment, come back to your repository to see the Pull Request. Once you merge it, you can go back to Proton and see the updated status of your newly created environment
+
+Feel free to reach out with questions or open a ticket with suggestions in our public roadmap at https://github.com/aws/aws-proton-public-roadmap
 
 Thank you!
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ aws proton update-environment-template-version \
         --region REGION
 ```
 9. Register your repository with Proton by following the instructions [here](https://docs.aws.amazon.com/proton/latest/adminguide/ag-create-repo.html)
-10. Deploy your environment in Proton by following the instructions [here](https://docs.aws.amazon.com/proton/latest/adminguide/ag-create-env.html#ag-create-env-pull-request). Change `GITHUB_USER` to be name of the GitHub account with the forked repository.
+10. Deploy your environment in Proton by following the instructions using the following commands. Change `GITHUB_USER` to be name of the GitHub account with the forked repository. For more information see the documentation [here](https://docs.aws.amazon.com/proton/latest/adminguide/ag-create-env.html#ag-create-env-pull-request)
 ```
  aws proton create-environment \
         --name "ENVIRONMENT_NAME" \

--- a/env_config.json
+++ b/env_config.json
@@ -1,10 +1,7 @@
 {
-    "env_name_1": {
-        "role": "arn:aws:iam::123456789:role/TerraformGitHubActionsRole",
-        "region": "us-west-2"
-    },
-    "env_name_2": {
-        "role": "arn:aws:iam::123456789:role/TerraformGitHubActionsRole",
-        "region": "us-west-2"
+    "sample-vpc-environment": {
+        "role": "arn:aws:iam::ACCOUNT_ID:role/ExampleGithubRole",
+        "region": "us-east-1",
+        "state_bucket":"aws-proton-terraform-bucket-ACCOUNT_ID"
     }
 }

--- a/sample-templates/sample-vpc-environment-template/v1/infrastructure/config.tf
+++ b/sample-templates/sample-vpc-environment-template/v1/infrastructure/config.tf
@@ -10,7 +10,8 @@ terraform {
 }
 
 # Configure the AWS Provider
-provider "aws" {
-  region = "us-west-2"
-}
+provider "aws" {}
 
+variable "aws_region" {
+  type = string
+}

--- a/sample-templates/sample-vpc-environment-template/v1/infrastructure/vpc.tf
+++ b/sample-templates/sample-vpc-environment-template/v1/infrastructure/vpc.tf
@@ -4,7 +4,7 @@ module "vpc" {
   name = var.environment.inputs.vpc_name
   cidr = "10.0.0.0/16"
 
-  azs             = [var.environment.inputs.az]
+  azs             = ["${var.aws_region}a"]
   private_subnets = ["10.0.1.0/24"]
   public_subnets  = ["10.0.101.0/24"]
 

--- a/sample-templates/sample-vpc-environment-template/v1/schema/schema.yaml
+++ b/sample-templates/sample-vpc-environment-template/v1/schema/schema.yaml
@@ -8,14 +8,8 @@ schema:
       type: object
       description: "Input properties for a vpc environment."
       properties:
-        az:
-          type: string
-          description: "The az you want your environment to deployed to, e.g. us-east-1a"
-          minLength: 1
-          maxLength: 10
         vpc_name:
           type: string
           description: "Name for vpc"
       required:
-        - az
         - vpc_name

--- a/specs/env-spec.yml
+++ b/specs/env-spec.yml
@@ -1,0 +1,3 @@
+proton: EnvironmentSpec
+spec:
+  vpc_name: aws-proton-sample-vpc


### PR DESCRIPTION
This PR represents a couple of updates to improve the usability of this sample template

### `proton_run.yml`
1. Updated the `proton_run` job to only run on changes that include and update to `deployment-metadata.json`. This will prevent the action from running when updates are made outside of Proton
2. Corrected confusing variable name semantics, we now use snake case for all input variables
3. Added `state_bucket` as an output of the account cloudformation stack. This allows us to use a different name for the CF stack and bucket. Additionally we now auto generate a bucket name based on the current account ID.
4. Updated the `proton_run` job to exit with an error if credentials can't be configured or the job is being run without required files. This improves error messages in these cases to help with debugging.

### `terraform.yml`
1. Updated the `terraform` job to exit if we fail to fetch credentials. All subsequent jobs will fail anyway so this just improves error messaging.
2. Removed hard-coded values for `state_bucket` and `region`. State bucket relates to (3) above, `region` meant that the template failed when the user specified a region other than `us-west-2`.
3. Moved from passing the region (which is used to determine valid az names for the vpc) through the template to directly injecting it via the `terraform` job. This reduces duplication and the chance of a config mismatch which would cause the template to fail.

### `GitHubConfiguration.yaml`
1. Removed the default value for repo name, we now pass that in as a command line variable since the default would never actually be valid.
2. Updated the Thumbprint value based on [this post](https://twitter.com/arkadiyt/status/1481418230082248714?s=20)
3. Switched to a dynamic name for the state bucket. This prevents accidental name collisions between customers and removes the naming constraints on the infrastructure stack.

### `README`
1. Updated with more command line examples and additional revisions for clarity

### `env_config.json`
1. Removed extraneous config 
2. Added `state_bucket` key as part of the move to a dynamic bucket name

### `config.tf`
1. To allow the template to be valid for regions other than `us-west-2` the region parameter was removed for the aws provider
2. Added an `aws_region` variable to enable that information to be passed in via the command line

### `vpc.tf`
1. As part of the move to not require the az name as an input to the Environment, we now automatically select an AZ based on the region provided. The main goal of this is to reduce the change of a misconfiguration between the region that the Environment is being deployed into an the user configuration.

### `schema.yml`
1. As part of the change mention above, we are removing the `az` parameter from the template since this will now be automatically generated.

### `env-spec.yml`
1. Added a sample spec file to allow the example to provide an example for anyone that is deploying via the command line.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
