### PR TITLE
Updated audience for Github OpenID

### DIFF
--- a/GitHubConfiguration.yaml
+++ b/GitHubConfiguration.yaml
@@ -33,8 +33,7 @@ Resources:
       Url: https://token.actions.githubusercontent.com
       ThumbprintList: [6938fd4d98bab03faadb97b34396831e3780aea1]
       ClientIdList:
-        - sigstore
-        - sts.amazon.com
+        - sts.amazonaws.com
 
   StateFileBucket:
     # This bucket will be used to store your Terraform Open Source state files


### PR DESCRIPTION
The [configure-aws-credentials](https://github.com/aws-actions/configure-aws-credentials) action has recently updated its instructions for creating an identity provider. This change updates the audience to be correct for the latest version.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
