### PR TITLE
Enabled wild-card support ("*") for the environment name 

### DIFF
--- a/.github/workflows/proton_run.yml
+++ b/.github/workflows/proton_run.yml
@@ -86,47 +86,35 @@ jobs:
           read -a split_arn <<< "$modified_resource_arn"
           proton_region=${split_arn[3]}
           echo "::set-output name=proton_region::$proton_region"
-          
           deployment_id=$(jq -r '.deploymentId' ${{ steps.find-modified.outputs.deployment-metadata-path }})
           echo "::set-output name=deployment_id::$deployment_id"
-          
           is_deleted=$(jq -r '.isResourceDeleted' ${{ steps.find-modified.outputs.deployment-metadata-path }})
           echo "::set-output name=is_deleted::$is_deleted"
-          
-          
           if [[ "$modified_resource_arn" == *":environment/"* ]]; then
             environment_name=${modified_resource_arn##*/}
             working_directory="$environment_name/"
           elif [[ "$modified_resource_arn" == *"/service-instance/"* ]]; then
             environment_arn=$(jq -r '.resourceMetadata.environmentArn' ${{ steps.find-modified.outputs.deployment-metadata-path }})
             environment_name=${environment_arn##*/}
-          
             resource_portion=${modified_resource_arn##*:}
             IFS='/'
             read -a split_resources <<< "$resource_portion"
-          
             service_name=${split_resources[1]}
             instance_name=${split_resources[3]}
-          
             working_directory=$environment_name/$service_name-$instance_name/
           elif [[ "$modified_resource_arn" == *"/pipeline"* ]]; then
             environment_name="pipeline"
-          
             resource_portion=${modified_resource_arn##*:}
             IFS='/'
             read -a split_resources <<< "$resource_portion"
-          
             service_name=${split_resources[1]}
-          
             working_directory=pipeline/$service_name
           fi
-          
-          # Check if there is a match (exact or * as a wild-card) between the Proton env name and the env_config file  
           if [[ $(jq -r --arg env $environment_name 'has($env)' env_config.json) = "false" ]]; then
             if [[ $(jq -r --arg env $environment_name 'has("*")' env_config.json) = "false" ]]; then
               echo "Missing $environment_name or * from env_config.json, exiting"
-            exit 1
-            fi 
+              exit 1
+            fi
           fi
           
           echo "::set-output name=working_directory::$working_directory"
@@ -136,16 +124,15 @@ jobs:
             role_arn=$(jq -r --arg env $environment_name '.[$env]["role"]' env_config.json)
             target_region=$(jq -r --arg env $environment_name '.[$env]["region"]' env_config.json)
             state_bucket=$(jq -r --arg env $environment_name '.[$env]["state_bucket"]' env_config.json)
-          else 
+          else
             role_arn=$(jq -r --arg env $environment_name '.["*"]["role"]' env_config.json)
             target_region=$(jq -r --arg env $environment_name '.["*"]["region"]' env_config.json)
             state_bucket=$(jq -r --arg env $environment_name '.["*"]["state_bucket"]' env_config.json)
-          fi 
+          fi
           
           echo "::set-output name=role_arn::$role_arn"
           echo "::set-output name=target_region::$target_region"
           echo "::set-output name=state_bucket::$state_bucket"
-
   terraform:
     name: 'Terraform'
     needs: get-deployment-data
@@ -258,11 +245,9 @@ jobs:
         run: |
           # Get outputs as json
           outputs_json=$(terraform output -json)
-          
           # The outputs parameters expects a list of key=keyName,valueString=value key=key2Name,valueString=value2 etc...
           # So here we convert the output json into a shell array
           # NOTE: This will probably not play nicely with complex output objects (non primitives)
-          
           formatted_outputs=( $(echo $outputs_json | jq -r "to_entries|map(\"key=\(.key),valueString=\(.value.value|tostring)\")|.[]") )
           
           # Notify proton
@@ -274,7 +259,6 @@ jobs:
         run: |
           aws proton notify-resource-deployment-status-change --region ${{ needs.get-deployment-data.outputs.proton_region }} --resource-arn ${{ needs.get-deployment-data.outputs.resource_arn }} --status FAILED --deployment-id ${{ needs.get-deployment-data.outputs.deployment_id }}
           echo "Notify failure!"
-
   terraform-destroy:
     name: 'Run terraform destroy'
     needs:

--- a/.github/workflows/proton_run.yml
+++ b/.github/workflows/proton_run.yml
@@ -121,8 +121,16 @@ jobs:
           working_directory=pipeline/$service_name
         fi
 
-        if [[ $(jq -r --arg env $environment_name 'has($env)' env_config.json) = "false" ]]; then
-          if [[ $(jq -r --arg env $environment_name 'has("*")' env_config.json) = "false" ]]; then
+        if [[ $(jq -r --arg env $environment_name 'has($env)' env_config.json) = "true" ]]; then
+          role_arn=$(jq -r --arg env $environment_name '.[$env]["role"]' env_config.json)
+          target_region=$(jq -r --arg env $environment_name '.[$env]["region"]' env_config.json)
+          state_bucket=$(jq -r --arg env $environment_name '.[$env]["state_bucket"]' env_config.json)   
+        else     
+          if [[ $(jq -r --arg env $environment_name 'has("*")' env_config.json) = "true" ]]; then
+            role_arn=$(jq -r --arg env $environment_name '.["*"]["role"]' env_config.json)
+            target_region=$(jq -r --arg env $environment_name '.["*"]["region"]' env_config.json)
+            state_bucket=$(jq -r --arg env $environment_name '.["*"]["state_bucket"]' env_config.json)
+          else
             echo "Missing $environment_name or * from env_config.json, exiting"
             exit 1
           fi
@@ -130,16 +138,6 @@ jobs:
         
         echo "::set-output name=working_directory::$working_directory"
         echo "::set-output name=environment::$environment_name"
-        
-        if [[ $(jq -r --arg env $environment_name 'has($env)' env_config.json) = "true" ]]; then
-          role_arn=$(jq -r --arg env $environment_name '.[$env]["role"]' env_config.json)
-          target_region=$(jq -r --arg env $environment_name '.[$env]["region"]' env_config.json)
-          state_bucket=$(jq -r --arg env $environment_name '.[$env]["state_bucket"]' env_config.json)
-        else
-          role_arn=$(jq -r --arg env $environment_name '.["*"]["role"]' env_config.json)
-          target_region=$(jq -r --arg env $environment_name '.["*"]["region"]' env_config.json)
-          state_bucket=$(jq -r --arg env $environment_name '.["*"]["state_bucket"]' env_config.json)
-        fi
         
         echo "::set-output name=role_arn::$role_arn"
         echo "::set-output name=target_region::$target_region"

--- a/.github/workflows/proton_run.yml
+++ b/.github/workflows/proton_run.yml
@@ -39,100 +39,112 @@ jobs:
     continue-on-error: true
     
     steps:
-      # Checkout the repository to the GitHub Actions runner
-      - name: Checkout
-        uses: actions/checkout@v2
+    # Checkout the repository to the GitHub Actions runner
+    - name: Checkout
+      uses: actions/checkout@v2
 
-      - name: Verify env_config updated
-        run: |
-          if grep -q REPLACE_ME env_config.json; then
-            echo "You must update env_config.json or update this workflow to not require it."
-            exit 1
-          fi
-
-      - name: Get changed files
-        id: files
-        uses: jitterbit/get-changed-files@v1
-
-      - name: Find modified resource
-        id: find-modified
-        run: |
-          found=false
-          for changed_file in ${{ steps.files.outputs.all }}; do
-            if [[ "$changed_file" == *".proton/deployment-metadata.json" ]]; then
-              echo "found file"
-              if [[ "$found" == true ]]; then
-                echo "More than one resource found to have a new deployment, I'm not sure which one to update, exiting."
-                exit 1
-              fi
-              echo "setting found to true"
-              found=true
-              echo "setting outputs"
-              echo "::set-output name=deployment-metadata-path::$changed_file"
-            fi
-          done
-          if [[ "$found" == false ]]; then
-            echo "No change made to deployment-metadata.json, exiting"
-            exit 1
-          fi
-
-      - name: Get data
-        id: get-data
-        run: |
-          modified_resource_arn=$(jq -r '.resourceMetadata.arn' ${{ steps.find-modified.outputs.deployment-metadata-path }})
-          echo "::set-output name=resource_arn::$modified_resource_arn"
-          
-          IFS=':'
-          read -a split_arn <<< "$modified_resource_arn"
-          proton_region=${split_arn[3]}
-          echo "::set-output name=proton_region::$proton_region"
-          deployment_id=$(jq -r '.deploymentId' ${{ steps.find-modified.outputs.deployment-metadata-path }})
-          echo "::set-output name=deployment_id::$deployment_id"
-          is_deleted=$(jq -r '.isResourceDeleted' ${{ steps.find-modified.outputs.deployment-metadata-path }})
-          echo "::set-output name=is_deleted::$is_deleted"
-          if [[ "$modified_resource_arn" == *":environment/"* ]]; then
-            environment_name=${modified_resource_arn##*/}
-            working_directory="$environment_name/"
-          elif [[ "$modified_resource_arn" == *"/service-instance/"* ]]; then
-            environment_arn=$(jq -r '.resourceMetadata.environmentArn' ${{ steps.find-modified.outputs.deployment-metadata-path }})
-            environment_name=${environment_arn##*/}
-            resource_portion=${modified_resource_arn##*:}
-            IFS='/'
-            read -a split_resources <<< "$resource_portion"
-            service_name=${split_resources[1]}
-            instance_name=${split_resources[3]}
-            working_directory=$environment_name/$service_name-$instance_name/
-          elif [[ "$modified_resource_arn" == *"/pipeline"* ]]; then
-            environment_name="pipeline"
-            resource_portion=${modified_resource_arn##*:}
-            IFS='/'
-            read -a split_resources <<< "$resource_portion"
-            service_name=${split_resources[1]}
-            working_directory=pipeline/$service_name
-          fi
-          if [[ $(jq -r --arg env $environment_name 'has($env)' env_config.json) = "false" ]]; then
-            if [[ $(jq -r --arg env $environment_name 'has("*")' env_config.json) = "false" ]]; then
-              echo "Missing $environment_name or * from env_config.json, exiting"
+    - name: Verify env_config updated
+      run: |
+        if grep -q REPLACE_ME env_config.json; then
+          echo "You must update env_config.json or update this workflow to not require it."
+          exit 1
+        fi
+      
+    - name: Get changed files
+      id: files
+      uses: jitterbit/get-changed-files@v1
+      
+    - name: Find modified resource
+      id: find-modified
+      run: |
+        found=false
+        for changed_file in ${{ steps.files.outputs.all }}; do
+          if [[ "$changed_file" == *".proton/deployment-metadata.json" ]]; then
+            echo "found file"
+            if [[ "$found" == true ]]; then
+              echo "More than one resource found to have a new deployment, I'm not sure which one to update, exiting."
               exit 1
             fi
+            echo "setting found to true"
+            found=true
+            echo "setting outputs"
+            echo "::set-output name=deployment-metadata-path::$changed_file"
           fi
-          
-          echo "::set-output name=working_directory::$working_directory"
-          echo "::set-output name=environment::$environment_name"
-          
-          if [[ $(jq -r --arg env $environment_name 'has($env)' env_config.json) = "true" ]]; then
-            role_arn=$(jq -r --arg env $environment_name '.[$env]["role"]' env_config.json)
-            target_region=$(jq -r --arg env $environment_name '.[$env]["region"]' env_config.json)
-            state_bucket=$(jq -r --arg env $environment_name '.[$env]["state_bucket"]' env_config.json)
-          else
-            role_arn=$(jq -r --arg env $environment_name '.["*"]["role"]' env_config.json)
-            target_region=$(jq -r --arg env $environment_name '.["*"]["region"]' env_config.json)
-            state_bucket=$(jq -r --arg env $environment_name '.["*"]["state_bucket"]' env_config.json)
+        done
+        if [[ "$found" == false ]]; then
+          echo "No change made to deployment-metadata.json, exiting"
+          exit 1
+        fi
+    
+    - name: Get data
+      id: get-data
+      run: |
+        modified_resource_arn=$(jq -r '.resourceMetadata.arn' ${{ steps.find-modified.outputs.deployment-metadata-path }})
+        echo "::set-output name=resource_arn::$modified_resource_arn"
+        
+        IFS=':'
+        read -a split_arn <<< "$modified_resource_arn"
+        proton_region=${split_arn[3]}
+        echo "::set-output name=proton_region::$proton_region"
+
+        deployment_id=$(jq -r '.deploymentId' ${{ steps.find-modified.outputs.deployment-metadata-path }})
+        echo "::set-output name=deployment_id::$deployment_id"
+
+        is_deleted=$(jq -r '.isResourceDeleted' ${{ steps.find-modified.outputs.deployment-metadata-path }})
+        echo "::set-output name=is_deleted::$is_deleted"
+
+
+        if [[ "$modified_resource_arn" == *":environment/"* ]]; then
+          environment_name=${modified_resource_arn##*/}
+          working_directory="$environment_name/"
+        elif [[ "$modified_resource_arn" == *"/service-instance/"* ]]; then
+          environment_arn=$(jq -r '.resourceMetadata.environmentArn' ${{ steps.find-modified.outputs.deployment-metadata-path }})
+          environment_name=${environment_arn##*/}
+
+          resource_portion=${modified_resource_arn##*:}
+          IFS='/'
+          read -a split_resources <<< "$resource_portion"
+
+          service_name=${split_resources[1]}
+          instance_name=${split_resources[3]}
+
+          working_directory=$environment_name/$service_name-$instance_name/
+        elif [[ "$modified_resource_arn" == *"/pipeline"* ]]; then
+          environment_name="pipeline"
+
+          resource_portion=${modified_resource_arn##*:}
+          IFS='/'
+          read -a split_resources <<< "$resource_portion"
+
+          service_name=${split_resources[1]}
+
+          working_directory=pipeline/$service_name
+        fi
+
+        if [[ $(jq -r --arg env $environment_name 'has($env)' env_config.json) = "false" ]]; then
+          if [[ $(jq -r --arg env $environment_name 'has("*")' env_config.json) = "false" ]]; then
+            echo "Missing $environment_name or * from env_config.json, exiting"
+            exit 1
           fi
-          
-          echo "::set-output name=role_arn::$role_arn"
-          echo "::set-output name=target_region::$target_region"
-          echo "::set-output name=state_bucket::$state_bucket"
+        fi
+        
+        echo "::set-output name=working_directory::$working_directory"
+        echo "::set-output name=environment::$environment_name"
+        
+        if [[ $(jq -r --arg env $environment_name 'has($env)' env_config.json) = "true" ]]; then
+          role_arn=$(jq -r --arg env $environment_name '.[$env]["role"]' env_config.json)
+          target_region=$(jq -r --arg env $environment_name '.[$env]["region"]' env_config.json)
+          state_bucket=$(jq -r --arg env $environment_name '.[$env]["state_bucket"]' env_config.json)
+        else
+          role_arn=$(jq -r --arg env $environment_name '.["*"]["role"]' env_config.json)
+          target_region=$(jq -r --arg env $environment_name '.["*"]["region"]' env_config.json)
+          state_bucket=$(jq -r --arg env $environment_name '.["*"]["state_bucket"]' env_config.json)
+        fi
+        
+        echo "::set-output name=role_arn::$role_arn"
+        echo "::set-output name=target_region::$target_region"
+        echo "::set-output name=state_bucket::$state_bucket"
+
   terraform:
     name: 'Terraform'
     needs: get-deployment-data
@@ -142,7 +154,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-
+    
     defaults:
       run:
         working-directory: ${{ needs.get-deployment-data.outputs.working_directory }}
@@ -154,148 +166,151 @@ jobs:
       success: ${{ steps.mark_success.outputs.success }}
 
     steps:
-      # Checkout the repository to the GitHub Actions runner
-      - name: Checkout
-        uses: actions/checkout@v2
+    # Checkout the repository to the GitHub Actions runner
+    - name: Checkout
+      uses: actions/checkout@v2
+    
+    - name: Configure AWS Credentials
+      id: assume_role
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-region: ${{ needs.get-deployment-data.outputs.target_region }}
+        role-to-assume: ${{ needs.get-deployment-data.outputs.role_arn }}
+        role-session-name: TF-Github-Actions
 
-      - name: Configure AWS Credentials
-        id: assume_role
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-region: ${{ needs.get-deployment-data.outputs.target_region }}
-          role-to-assume: ${{ needs.get-deployment-data.outputs.role_arn }}
-          role-session-name: TF-Github-Actions
+    # Install the latest version of Terraform CLI and configure the Terraform CLI configuration file with a Terraform Cloud user API token
+    - name: Setup Terraform
+      id: tf_setup
+      uses: hashicorp/setup-terraform@v1
+      with:
+        terraform_version: 1.0.7
+        terraform_wrapper: false
 
-      # Install the latest version of Terraform CLI and configure the Terraform CLI configuration file with a Terraform Cloud user API token
-      - name: Setup Terraform
-        id: tf_setup
-        uses: hashicorp/setup-terraform@v1
-        with:
-          terraform_version: 1.0.7
-          terraform_wrapper: false
+    # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
+    - name: Terraform Init
+      id: tf_init
+      run: terraform init -backend-config="bucket=${{ needs.get-deployment-data.outputs.state_bucket }}" -backend-config="key=${{ needs.get-deployment-data.outputs.working_directory }}terraform.tfstate" -backend-config="region=${{ needs.get-deployment-data.outputs.target_region }}"
 
-      # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
-      - name: Terraform Init
-        id: tf_init
-        run: terraform init -backend-config="bucket=${{ needs.get-deployment-data.outputs.state_bucket }}" -backend-config="key=${{ needs.get-deployment-data.outputs.working_directory }}terraform.tfstate" -backend-config="region=${{ needs.get-deployment-data.outputs.target_region }}"
+    # Checks that all Terraform configuration files adhere to a canonical format
+    - name: Terraform Format
+      id: tf_fmt
+      run: terraform fmt -diff -check
 
-      # Checks that all Terraform configuration files adhere to a canonical format
-      - name: Terraform Format
-        id: tf_fmt
-        run: terraform fmt -diff -check
+    # Generates an execution plan for Terraform
+    - name: Terraform Plan
+      id: tf_plan
+      run: terraform plan -var="aws_region=${{ needs.get-deployment-data.outputs.target_region }}"
 
-      # Generates an execution plan for Terraform
-      - name: Terraform Plan
-        id: tf_plan
-        run: terraform plan -var="aws_region=${{ needs.get-deployment-data.outputs.target_region }}"
-
-      # On push to main, build or change infrastructure according to Terraform configuration files
-      # Note: It is recommended to set up a required "strict" status check in your repository for "Terraform Cloud". See the documentation on "strict" required status checks for more information: https://help.github.com/en/github/administering-a-repository/types-of-required-status-checks
-      - name: Terraform Apply
-        id: tf_apply
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-        run: terraform apply -auto-approve -var="aws_region=${{ needs.get-deployment-data.outputs.target_region }}"
-
-      # If this completes, then the entire workflow has successfully completed
-      - name: Mark Success
-        id: mark_success
-        run: echo "::set-output name=success::True"
+    # On push to main, build or change infrastructure according to Terraform configuration files
+    # Note: It is recommended to set up a required "strict" status check in your repository for "Terraform Cloud". See the documentation on "strict" required status checks for more information: https://help.github.com/en/github/administering-a-repository/types-of-required-status-checks
+    - name: Terraform Apply
+      id: tf_apply
+      if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+      run: terraform apply -auto-approve -var="aws_region=${{ needs.get-deployment-data.outputs.target_region }}"
+    
+    # If this completes, then the entire workflow has successfully completed
+    - name: Mark Success
+      id: mark_success
+      run: echo "::set-output name=success::True"
 
   notify-proton:
     name: 'Notify Proton'
-    needs:
-      - get-deployment-data
-      - terraform
+    needs: 
+    - get-deployment-data
+    - terraform
     runs-on: ubuntu-latest
     environment: ${{ needs.get-deployment-data.outputs.environment }}
 
     if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.get-deployment-data.outputs.is_deleted == 'false'
-
+    
     permissions:
       id-token: write
       contents: read
-
+      
     defaults:
       run:
         working-directory: ${{ needs.get-deployment-data.outputs.working_directory }}
         shell: bash # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
 
     steps:
-      # Checkout the repository to the GitHub Actions runner
-      - name: Checkout
-        uses: actions/checkout@v2
+    # Checkout the repository to the GitHub Actions runner
+    - name: Checkout
+      uses: actions/checkout@v2
+      
+    - name: Configure AWS Credentials
+      id: assume_role
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-region: ${{ needs.get-deployment-data.outputs.target_region }}
+        role-to-assume: ${{ needs.get-deployment-data.outputs.role_arn }}
+        role-session-name: TF-Github-Actions-Notify-Proton
+        
+    # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
+    - name: Terraform Init
+      id: tf_init
+      continue-on-error: true
+      run: terraform init -backend-config="bucket=${{ needs.get-deployment-data.outputs.state_bucket }}" -backend-config="key=${{ needs.get-deployment-data.outputs.working_directory }}terraform.tfstate" -backend-config="region=${{ needs.get-deployment-data.outputs.target_region }}"
 
-      - name: Configure AWS Credentials
-        id: assume_role
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-region: ${{ needs.get-deployment-data.outputs.target_region }}
-          role-to-assume: ${{ needs.get-deployment-data.outputs.role_arn }}
-          role-session-name: TF-Github-Actions-Notify-Proton
+    - name: Notify Proton Success
+      id: notify_success
+      if: needs.terraform.outputs.success == 'True' && steps.tf_init.outcome == 'success'
+      run: |
+        # Get outputs as json
+        outputs_json=$(terraform output -json)
 
-      # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
-      - name: Terraform Init
-        id: tf_init
-        continue-on-error: true
-        run: terraform init -backend-config="bucket=${{ needs.get-deployment-data.outputs.state_bucket }}" -backend-config="key=${{ needs.get-deployment-data.outputs.working_directory }}terraform.tfstate" -backend-config="region=${{ needs.get-deployment-data.outputs.target_region }}"
+        # The outputs parameters expects a list of key=keyName,valueString=value key=key2Name,valueString=value2 etc...
+        # So here we convert the output json into a shell array
+        # NOTE: This will probably not play nicely with complex output objects (non primitives)
 
-      - name: Notify Proton Success
-        id: notify_success
-        if: needs.terraform.outputs.success == 'True' && steps.tf_init.outcome == 'success'
-        run: |
-          # Get outputs as json
-          outputs_json=$(terraform output -json)
-          # The outputs parameters expects a list of key=keyName,valueString=value key=key2Name,valueString=value2 etc...
-          # So here we convert the output json into a shell array
-          # NOTE: This will probably not play nicely with complex output objects (non primitives)
-          formatted_outputs=( $(echo $outputs_json | jq -r "to_entries|map(\"key=\(.key),valueString=\(.value.value|tostring)\")|.[]") )
-          
-          # Notify proton
-          aws proton notify-resource-deployment-status-change --region ${{ needs.get-deployment-data.outputs.proton_region }} --resource-arn ${{ needs.get-deployment-data.outputs.resource_arn }} --status SUCCEEDED --deployment-id ${{ needs.get-deployment-data.outputs.deployment_id }} --outputs ${formatted_outputs[*]}
-          echo "Notify success!"   
+        formatted_outputs=( $(echo $outputs_json | jq -r "to_entries|map(\"key=\(.key),valueString=\(.value.value|tostring)\")|.[]") )
+      
+        # Notify proton
+        aws proton notify-resource-deployment-status-change --region ${{ needs.get-deployment-data.outputs.proton_region }} --resource-arn ${{ needs.get-deployment-data.outputs.resource_arn }} --status SUCCEEDED --deployment-id ${{ needs.get-deployment-data.outputs.deployment_id }} --outputs ${formatted_outputs[*]}
+        echo "Notify success!"   
+        
+    - name: Notify Proton Failure
+      if: needs.terraform.outputs.success != 'True' || steps.tf_init.outcome != 'success'
+      run: |
+        aws proton notify-resource-deployment-status-change --region ${{ needs.get-deployment-data.outputs.proton_region }} --resource-arn ${{ needs.get-deployment-data.outputs.resource_arn }} --status FAILED --deployment-id ${{ needs.get-deployment-data.outputs.deployment_id }}
+        echo "Notify failure!"
 
-      - name: Notify Proton Failure
-        if: needs.terraform.outputs.success != 'True' || steps.tf_init.outcome != 'success'
-        run: |
-          aws proton notify-resource-deployment-status-change --region ${{ needs.get-deployment-data.outputs.proton_region }} --resource-arn ${{ needs.get-deployment-data.outputs.resource_arn }} --status FAILED --deployment-id ${{ needs.get-deployment-data.outputs.deployment_id }}
-          echo "Notify failure!"
   terraform-destroy:
     name: 'Run terraform destroy'
-    needs:
-      - get-deployment-data
+    needs: 
+    - get-deployment-data
     runs-on: ubuntu-latest
     environment: ${{ needs.get-deployment-data.outputs.environment }}
 
     if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.get-deployment-data.outputs.is_deleted == 'true'
-
+    
     permissions:
       id-token: write
       contents: read
-
+      
     defaults:
       run:
         working-directory: ${{ needs.get-deployment-data.outputs.working_directory }}
         shell: bash # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
 
     steps:
-      # Checkout the repository to the GitHub Actions runner
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Configure AWS Credentials
-        id: assume_role
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-region: ${{ needs.get-deployment-data.outputs.target_region }}
-          role-to-assume: ${{ needs.get-deployment-data.outputs.role_arn }}
-          role-session-name: TF-Github-Actions-Notify-Proton
-
-      # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
-      - name: Terraform Init
-        id: tf_init
-        continue-on-error: true
-        run: terraform init -backend-config="bucket=${{ needs.get-deployment-data.outputs.state_bucket }}" -backend-config="key=${{ needs.get-deployment-data.outputs.working_directory }}terraform.tfstate" -backend-config="region=${{ needs.get-deployment-data.outputs.target_region }}"
-
-      - name: Terraform Destroy
-        id: tf_destroy
-        run: terraform apply -auto-approve -destroy -var="aws_region=${{ needs.get-deployment-data.outputs.target_region }}"
+    # Checkout the repository to the GitHub Actions runner
+    - name: Checkout
+      uses: actions/checkout@v2
+      
+    - name: Configure AWS Credentials
+      id: assume_role
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-region: ${{ needs.get-deployment-data.outputs.target_region }}
+        role-to-assume: ${{ needs.get-deployment-data.outputs.role_arn }}
+        role-session-name: TF-Github-Actions-Notify-Proton
+        
+    # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
+    - name: Terraform Init
+      id: tf_init
+      continue-on-error: true
+      run: terraform init -backend-config="bucket=${{ needs.get-deployment-data.outputs.state_bucket }}" -backend-config="key=${{ needs.get-deployment-data.outputs.working_directory }}terraform.tfstate" -backend-config="region=${{ needs.get-deployment-data.outputs.target_region }}"
+    
+    - name: Terraform Destroy
+      id: tf_destroy
+      run: terraform apply -auto-approve -destroy -var="aws_region=${{ needs.get-deployment-data.outputs.target_region }}"

--- a/.github/workflows/proton_run.yml
+++ b/.github/workflows/proton_run.yml
@@ -39,104 +39,112 @@ jobs:
     continue-on-error: true
     
     steps:
-    # Checkout the repository to the GitHub Actions runner
-    - name: Checkout
-      uses: actions/checkout@v2
+      # Checkout the repository to the GitHub Actions runner
+      - name: Checkout
+        uses: actions/checkout@v2
 
-    - name: Verify env_config updated
-      run: |
-        if grep -q REPLACE_ME env_config.json; then
-          echo "You must update env_config.json or update this workflow to not require it."
-          exit 1
-        fi
-      
-    - name: Get changed files
-      id: files
-      uses: jitterbit/get-changed-files@v1
-      
-    - name: Find modified resource
-      id: find-modified
-      run: |
-        found=false
-        for changed_file in ${{ steps.files.outputs.all }}; do
-          if [[ "$changed_file" == *".proton/deployment-metadata.json" ]]; then
-            echo "found file"
-            if [[ "$found" == true ]]; then
-              echo "More than one resource found to have a new deployment, I'm not sure which one to update, exiting."
-              exit 1
-            fi
-            echo "setting found to true"
-            found=true
-            echo "setting outputs"
-            echo "::set-output name=deployment-metadata-path::$changed_file"
+      - name: Verify env_config updated
+        run: |
+          if grep -q REPLACE_ME env_config.json; then
+            echo "You must update env_config.json or update this workflow to not require it."
+            exit 1
           fi
-        done
-        if [[ "$found" == false ]]; then
-          echo "No change made to deployment-metadata.json, exiting"
-          exit 1
-        fi
-    
-    - name: Get data
-      id: get-data
-      run: |
-        modified_resource_arn=$(jq -r '.resourceMetadata.arn' ${{ steps.find-modified.outputs.deployment-metadata-path }})
-        echo "::set-output name=resource_arn::$modified_resource_arn"
-        
-        IFS=':'
-        read -a split_arn <<< "$modified_resource_arn"
-        proton_region=${split_arn[3]}
-        echo "::set-output name=proton_region::$proton_region"
 
-        deployment_id=$(jq -r '.deploymentId' ${{ steps.find-modified.outputs.deployment-metadata-path }})
-        echo "::set-output name=deployment_id::$deployment_id"
+      - name: Get changed files
+        id: files
+        uses: jitterbit/get-changed-files@v1
 
-        is_deleted=$(jq -r '.isResourceDeleted' ${{ steps.find-modified.outputs.deployment-metadata-path }})
-        echo "::set-output name=is_deleted::$is_deleted"
+      - name: Find modified resource
+        id: find-modified
+        run: |
+          found=false
+          for changed_file in ${{ steps.files.outputs.all }}; do
+            if [[ "$changed_file" == *".proton/deployment-metadata.json" ]]; then
+              echo "found file"
+              if [[ "$found" == true ]]; then
+                echo "More than one resource found to have a new deployment, I'm not sure which one to update, exiting."
+                exit 1
+              fi
+              echo "setting found to true"
+              found=true
+              echo "setting outputs"
+              echo "::set-output name=deployment-metadata-path::$changed_file"
+            fi
+          done
+          if [[ "$found" == false ]]; then
+            echo "No change made to deployment-metadata.json, exiting"
+            exit 1
+          fi
 
-
-        if [[ "$modified_resource_arn" == *":environment/"* ]]; then
-          environment_name=${modified_resource_arn##*/}
-          working_directory="$environment_name/"
-        elif [[ "$modified_resource_arn" == *"/service-instance/"* ]]; then
-          environment_arn=$(jq -r '.resourceMetadata.environmentArn' ${{ steps.find-modified.outputs.deployment-metadata-path }})
-          environment_name=${environment_arn##*/}
-
-          resource_portion=${modified_resource_arn##*:}
-          IFS='/'
-          read -a split_resources <<< "$resource_portion"
-
-          service_name=${split_resources[1]}
-          instance_name=${split_resources[3]}
-
-          working_directory=$environment_name/$service_name-$instance_name/
-        elif [[ "$modified_resource_arn" == *"/pipeline"* ]]; then
-          environment_name="pipeline"
-
-          resource_portion=${modified_resource_arn##*:}
-          IFS='/'
-          read -a split_resources <<< "$resource_portion"
-
-          service_name=${split_resources[1]}
-
-          working_directory=pipeline/$service_name
-        fi
-
-        if [[ $(jq -r --arg env $environment_name 'has($env)' env_config.json) = "false" ]]; then
-          echo "Missing $environment_name from env_config.json, exiting"
-          exit 1
-        fi
-
-        echo "::set-output name=working_directory::$working_directory"
-        echo "::set-output name=environment::$environment_name"
-        
-        role_arn=$(jq -r --arg env $environment_name '.[$env]["role"]' env_config.json)
-        echo "::set-output name=role_arn::$role_arn"
-
-        target_region=$(jq -r --arg env $environment_name '.[$env]["region"]' env_config.json)
-        echo "::set-output name=target_region::$target_region"
-
-        state_bucket=$(jq -r --arg env $environment_name '.[$env]["state_bucket"]' env_config.json)
-        echo "::set-output name=state_bucket::$state_bucket"
+      - name: Get data
+        id: get-data
+        run: |
+          modified_resource_arn=$(jq -r '.resourceMetadata.arn' ${{ steps.find-modified.outputs.deployment-metadata-path }})
+          echo "::set-output name=resource_arn::$modified_resource_arn"
+          
+          IFS=':'
+          read -a split_arn <<< "$modified_resource_arn"
+          proton_region=${split_arn[3]}
+          echo "::set-output name=proton_region::$proton_region"
+          
+          deployment_id=$(jq -r '.deploymentId' ${{ steps.find-modified.outputs.deployment-metadata-path }})
+          echo "::set-output name=deployment_id::$deployment_id"
+          
+          is_deleted=$(jq -r '.isResourceDeleted' ${{ steps.find-modified.outputs.deployment-metadata-path }})
+          echo "::set-output name=is_deleted::$is_deleted"
+          
+          
+          if [[ "$modified_resource_arn" == *":environment/"* ]]; then
+            environment_name=${modified_resource_arn##*/}
+            working_directory="$environment_name/"
+          elif [[ "$modified_resource_arn" == *"/service-instance/"* ]]; then
+            environment_arn=$(jq -r '.resourceMetadata.environmentArn' ${{ steps.find-modified.outputs.deployment-metadata-path }})
+            environment_name=${environment_arn##*/}
+          
+            resource_portion=${modified_resource_arn##*:}
+            IFS='/'
+            read -a split_resources <<< "$resource_portion"
+          
+            service_name=${split_resources[1]}
+            instance_name=${split_resources[3]}
+          
+            working_directory=$environment_name/$service_name-$instance_name/
+          elif [[ "$modified_resource_arn" == *"/pipeline"* ]]; then
+            environment_name="pipeline"
+          
+            resource_portion=${modified_resource_arn##*:}
+            IFS='/'
+            read -a split_resources <<< "$resource_portion"
+          
+            service_name=${split_resources[1]}
+          
+            working_directory=pipeline/$service_name
+          fi
+          
+          # Check if there is a match (exact or * as a wild-card) between the Proton env name and the env_config file  
+          if [[ $(jq -r --arg env $environment_name 'has($env)' env_config.json) = "false" ]]; then
+            if [[ $(jq -r --arg env $environment_name 'has("*")' env_config.json) = "false" ]]; then
+              echo "Missing $environment_name or * from env_config.json, exiting"
+            exit 1
+            fi 
+          fi
+          
+          echo "::set-output name=working_directory::$working_directory"
+          echo "::set-output name=environment::$environment_name"
+          
+          if [[ $(jq -r --arg env $environment_name 'has($env)' env_config.json) = "true" ]]; then
+            role_arn=$(jq -r --arg env $environment_name '.[$env]["role"]' env_config.json)
+            target_region=$(jq -r --arg env $environment_name '.[$env]["region"]' env_config.json)
+            state_bucket=$(jq -r --arg env $environment_name '.[$env]["state_bucket"]' env_config.json)
+          else 
+            role_arn=$(jq -r --arg env $environment_name '.["*"]["role"]' env_config.json)
+            target_region=$(jq -r --arg env $environment_name '.["*"]["region"]' env_config.json)
+            state_bucket=$(jq -r --arg env $environment_name '.["*"]["state_bucket"]' env_config.json)
+          fi 
+          
+          echo "::set-output name=role_arn::$role_arn"
+          echo "::set-output name=target_region::$target_region"
+          echo "::set-output name=state_bucket::$state_bucket"
 
   terraform:
     name: 'Terraform'
@@ -147,7 +155,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    
+
     defaults:
       run:
         working-directory: ${{ needs.get-deployment-data.outputs.working_directory }}
@@ -159,151 +167,151 @@ jobs:
       success: ${{ steps.mark_success.outputs.success }}
 
     steps:
-    # Checkout the repository to the GitHub Actions runner
-    - name: Checkout
-      uses: actions/checkout@v2
-    
-    - name: Configure AWS Credentials
-      id: assume_role
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        aws-region: ${{ needs.get-deployment-data.outputs.target_region }}
-        role-to-assume: ${{ needs.get-deployment-data.outputs.role_arn }}
-        role-session-name: TF-Github-Actions
+      # Checkout the repository to the GitHub Actions runner
+      - name: Checkout
+        uses: actions/checkout@v2
 
-    # Install the latest version of Terraform CLI and configure the Terraform CLI configuration file with a Terraform Cloud user API token
-    - name: Setup Terraform
-      id: tf_setup
-      uses: hashicorp/setup-terraform@v1
-      with:
-        terraform_version: 1.0.7
-        terraform_wrapper: false
+      - name: Configure AWS Credentials
+        id: assume_role
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: ${{ needs.get-deployment-data.outputs.target_region }}
+          role-to-assume: ${{ needs.get-deployment-data.outputs.role_arn }}
+          role-session-name: TF-Github-Actions
 
-    # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
-    - name: Terraform Init
-      id: tf_init
-      run: terraform init -backend-config="bucket=${{ needs.get-deployment-data.outputs.state_bucket }}" -backend-config="key=${{ needs.get-deployment-data.outputs.working_directory }}terraform.tfstate" -backend-config="region=${{ needs.get-deployment-data.outputs.target_region }}"
+      # Install the latest version of Terraform CLI and configure the Terraform CLI configuration file with a Terraform Cloud user API token
+      - name: Setup Terraform
+        id: tf_setup
+        uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: 1.0.7
+          terraform_wrapper: false
 
-    # Checks that all Terraform configuration files adhere to a canonical format
-    - name: Terraform Format
-      id: tf_fmt
-      run: terraform fmt -diff -check
+      # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
+      - name: Terraform Init
+        id: tf_init
+        run: terraform init -backend-config="bucket=${{ needs.get-deployment-data.outputs.state_bucket }}" -backend-config="key=${{ needs.get-deployment-data.outputs.working_directory }}terraform.tfstate" -backend-config="region=${{ needs.get-deployment-data.outputs.target_region }}"
 
-    # Generates an execution plan for Terraform
-    - name: Terraform Plan
-      id: tf_plan
-      run: terraform plan -var="aws_region=${{ needs.get-deployment-data.outputs.target_region }}"
+      # Checks that all Terraform configuration files adhere to a canonical format
+      - name: Terraform Format
+        id: tf_fmt
+        run: terraform fmt -diff -check
 
-    # On push to main, build or change infrastructure according to Terraform configuration files
-    # Note: It is recommended to set up a required "strict" status check in your repository for "Terraform Cloud". See the documentation on "strict" required status checks for more information: https://help.github.com/en/github/administering-a-repository/types-of-required-status-checks
-    - name: Terraform Apply
-      id: tf_apply
-      if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-      run: terraform apply -auto-approve -var="aws_region=${{ needs.get-deployment-data.outputs.target_region }}"
-    
-    # If this completes, then the entire workflow has successfully completed
-    - name: Mark Success
-      id: mark_success
-      run: echo "::set-output name=success::True"
+      # Generates an execution plan for Terraform
+      - name: Terraform Plan
+        id: tf_plan
+        run: terraform plan -var="aws_region=${{ needs.get-deployment-data.outputs.target_region }}"
+
+      # On push to main, build or change infrastructure according to Terraform configuration files
+      # Note: It is recommended to set up a required "strict" status check in your repository for "Terraform Cloud". See the documentation on "strict" required status checks for more information: https://help.github.com/en/github/administering-a-repository/types-of-required-status-checks
+      - name: Terraform Apply
+        id: tf_apply
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        run: terraform apply -auto-approve -var="aws_region=${{ needs.get-deployment-data.outputs.target_region }}"
+
+      # If this completes, then the entire workflow has successfully completed
+      - name: Mark Success
+        id: mark_success
+        run: echo "::set-output name=success::True"
 
   notify-proton:
     name: 'Notify Proton'
-    needs: 
-    - get-deployment-data
-    - terraform
+    needs:
+      - get-deployment-data
+      - terraform
     runs-on: ubuntu-latest
     environment: ${{ needs.get-deployment-data.outputs.environment }}
 
     if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.get-deployment-data.outputs.is_deleted == 'false'
-    
+
     permissions:
       id-token: write
       contents: read
-      
+
     defaults:
       run:
         working-directory: ${{ needs.get-deployment-data.outputs.working_directory }}
         shell: bash # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
 
     steps:
-    # Checkout the repository to the GitHub Actions runner
-    - name: Checkout
-      uses: actions/checkout@v2
-      
-    - name: Configure AWS Credentials
-      id: assume_role
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        aws-region: ${{ needs.get-deployment-data.outputs.target_region }}
-        role-to-assume: ${{ needs.get-deployment-data.outputs.role_arn }}
-        role-session-name: TF-Github-Actions-Notify-Proton
-        
-    # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
-    - name: Terraform Init
-      id: tf_init
-      continue-on-error: true
-      run: terraform init -backend-config="bucket=${{ needs.get-deployment-data.outputs.state_bucket }}" -backend-config="key=${{ needs.get-deployment-data.outputs.working_directory }}terraform.tfstate" -backend-config="region=${{ needs.get-deployment-data.outputs.target_region }}"
+      # Checkout the repository to the GitHub Actions runner
+      - name: Checkout
+        uses: actions/checkout@v2
 
-    - name: Notify Proton Success
-      id: notify_success
-      if: needs.terraform.outputs.success == 'True' && steps.tf_init.outcome == 'success'
-      run: |
-        # Get outputs as json
-        outputs_json=$(terraform output -json)
+      - name: Configure AWS Credentials
+        id: assume_role
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: ${{ needs.get-deployment-data.outputs.target_region }}
+          role-to-assume: ${{ needs.get-deployment-data.outputs.role_arn }}
+          role-session-name: TF-Github-Actions-Notify-Proton
 
-        # The outputs parameters expects a list of key=keyName,valueString=value key=key2Name,valueString=value2 etc...
-        # So here we convert the output json into a shell array
-        # NOTE: This will probably not play nicely with complex output objects (non primitives)
+      # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
+      - name: Terraform Init
+        id: tf_init
+        continue-on-error: true
+        run: terraform init -backend-config="bucket=${{ needs.get-deployment-data.outputs.state_bucket }}" -backend-config="key=${{ needs.get-deployment-data.outputs.working_directory }}terraform.tfstate" -backend-config="region=${{ needs.get-deployment-data.outputs.target_region }}"
 
-        formatted_outputs=( $(echo $outputs_json | jq -r "to_entries|map(\"key=\(.key),valueString=\(.value.value|tostring)\")|.[]") )
-      
-        # Notify proton
-        aws proton notify-resource-deployment-status-change --region ${{ needs.get-deployment-data.outputs.proton_region }} --resource-arn ${{ needs.get-deployment-data.outputs.resource_arn }} --status SUCCEEDED --deployment-id ${{ needs.get-deployment-data.outputs.deployment_id }} --outputs ${formatted_outputs[*]}
-        echo "Notify success!"   
-        
-    - name: Notify Proton Failure
-      if: needs.terraform.outputs.success != 'True' || steps.tf_init.outcome != 'success'
-      run: |
-        aws proton notify-resource-deployment-status-change --region ${{ needs.get-deployment-data.outputs.proton_region }} --resource-arn ${{ needs.get-deployment-data.outputs.resource_arn }} --status FAILED --deployment-id ${{ needs.get-deployment-data.outputs.deployment_id }}
-        echo "Notify failure!"
+      - name: Notify Proton Success
+        id: notify_success
+        if: needs.terraform.outputs.success == 'True' && steps.tf_init.outcome == 'success'
+        run: |
+          # Get outputs as json
+          outputs_json=$(terraform output -json)
+          
+          # The outputs parameters expects a list of key=keyName,valueString=value key=key2Name,valueString=value2 etc...
+          # So here we convert the output json into a shell array
+          # NOTE: This will probably not play nicely with complex output objects (non primitives)
+          
+          formatted_outputs=( $(echo $outputs_json | jq -r "to_entries|map(\"key=\(.key),valueString=\(.value.value|tostring)\")|.[]") )
+          
+          # Notify proton
+          aws proton notify-resource-deployment-status-change --region ${{ needs.get-deployment-data.outputs.proton_region }} --resource-arn ${{ needs.get-deployment-data.outputs.resource_arn }} --status SUCCEEDED --deployment-id ${{ needs.get-deployment-data.outputs.deployment_id }} --outputs ${formatted_outputs[*]}
+          echo "Notify success!"   
+
+      - name: Notify Proton Failure
+        if: needs.terraform.outputs.success != 'True' || steps.tf_init.outcome != 'success'
+        run: |
+          aws proton notify-resource-deployment-status-change --region ${{ needs.get-deployment-data.outputs.proton_region }} --resource-arn ${{ needs.get-deployment-data.outputs.resource_arn }} --status FAILED --deployment-id ${{ needs.get-deployment-data.outputs.deployment_id }}
+          echo "Notify failure!"
 
   terraform-destroy:
     name: 'Run terraform destroy'
-    needs: 
-    - get-deployment-data
+    needs:
+      - get-deployment-data
     runs-on: ubuntu-latest
     environment: ${{ needs.get-deployment-data.outputs.environment }}
 
     if: github.event_name == 'push' && github.ref == 'refs/heads/main' && needs.get-deployment-data.outputs.is_deleted == 'true'
-    
+
     permissions:
       id-token: write
       contents: read
-      
+
     defaults:
       run:
         working-directory: ${{ needs.get-deployment-data.outputs.working_directory }}
         shell: bash # Use the Bash shell regardless whether the GitHub Actions runner is ubuntu-latest, macos-latest, or windows-latest
 
     steps:
-    # Checkout the repository to the GitHub Actions runner
-    - name: Checkout
-      uses: actions/checkout@v2
-      
-    - name: Configure AWS Credentials
-      id: assume_role
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        aws-region: ${{ needs.get-deployment-data.outputs.target_region }}
-        role-to-assume: ${{ needs.get-deployment-data.outputs.role_arn }}
-        role-session-name: TF-Github-Actions-Notify-Proton
-        
-    # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
-    - name: Terraform Init
-      id: tf_init
-      continue-on-error: true
-      run: terraform init -backend-config="bucket=${{ needs.get-deployment-data.outputs.state_bucket }}" -backend-config="key=${{ needs.get-deployment-data.outputs.working_directory }}terraform.tfstate" -backend-config="region=${{ needs.get-deployment-data.outputs.target_region }}"
-    
-    - name: Terraform Destroy
-      id: tf_destroy
-      run: terraform apply -auto-approve -destroy -var="aws_region=${{ needs.get-deployment-data.outputs.target_region }}"
+      # Checkout the repository to the GitHub Actions runner
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Configure AWS Credentials
+        id: assume_role
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: ${{ needs.get-deployment-data.outputs.target_region }}
+          role-to-assume: ${{ needs.get-deployment-data.outputs.role_arn }}
+          role-session-name: TF-Github-Actions-Notify-Proton
+
+      # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
+      - name: Terraform Init
+        id: tf_init
+        continue-on-error: true
+        run: terraform init -backend-config="bucket=${{ needs.get-deployment-data.outputs.state_bucket }}" -backend-config="key=${{ needs.get-deployment-data.outputs.working_directory }}terraform.tfstate" -backend-config="region=${{ needs.get-deployment-data.outputs.target_region }}"
+
+      - name: Terraform Destroy
+        id: tf_destroy
+        run: terraform apply -auto-approve -destroy -var="aws_region=${{ needs.get-deployment-data.outputs.target_region }}"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Terraform OpenSource GitHub Actions automation template for AWS Proton
+eiifcckjbbr## Terraform OpenSource GitHub Actions automation template for AWS Proton
 
 Welcome! This repository should help you test how Proton works with Terraform Open Source to provision your infrastructure. In this repository you will find two things:
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-eiifcckjbbr## Terraform OpenSource GitHub Actions automation template for AWS Proton
+## Terraform OpenSource GitHub Actions automation template for AWS Proton
 
 Welcome! This repository should help you test how Proton works with Terraform Open Source to provision your infrastructure. In this repository you will find two things:
 


### PR DESCRIPTION
Description of changes: This PR introduces support for "*" as a valid environment name in the `env_config.yaml` file. When you set the env name to "*" the script will just assign region/bucket/IAM-role to all environments you create via Proton.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
