### PR TITLE
Add quotes so notify succeeds for string outputs

### DIFF
--- a/.github/workflows/proton_run.yml
+++ b/.github/workflows/proton_run.yml
@@ -263,7 +263,7 @@ jobs:
         formatted_outputs=( $(echo $outputs_json | jq -r "to_entries|map(\"key=\(.key),valueString=\(.value.value|tostring)\")|.[]") )
       
         # Notify proton
-        aws proton notify-resource-deployment-status-change --region ${{ needs.get-deployment-data.outputs.proton_region }} --resource-arn ${{ needs.get-deployment-data.outputs.resource_arn }} --status SUCCEEDED --deployment-id ${{ needs.get-deployment-data.outputs.deployment_id }} --outputs ${formatted_outputs[*]}
+        aws proton notify-resource-deployment-status-change --region ${{ needs.get-deployment-data.outputs.proton_region }} --resource-arn ${{ needs.get-deployment-data.outputs.resource_arn }} --status SUCCEEDED --deployment-id ${{ needs.get-deployment-data.outputs.deployment_id }} --outputs "${formatted_outputs[*]}"
         echo "Notify success!"   
         
     - name: Notify Proton Failure


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This will let Proton capture outputs such as an aws cli command without an error.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
